### PR TITLE
Fix component reusability regression by Vue router

### DIFF
--- a/src/bulma/pages/Router.vue
+++ b/src/bulma/pages/Router.vue
@@ -1,6 +1,6 @@
 <template>
     <fade mode="out-in">
-        <router-view :key="$route.path"/>
+        <router-view/>
     </fade>
 </template>
 


### PR DESCRIPTION
<router-view> works fine without key except for some rare edge-cases.
Having the key set to path prevents component reusability if the path changes.

v2 had this set to `JSON.stringify(this.$route.params)` which usually resulted in an empty object (thus not causing issues)

p.s.: looks like enso-ui org rights/it's repos are set differently than laravel-enso's, couldn't commit to the repos or set metadata like meta & projects