### PR TITLE
Fix translation regex, support : in keys

### DIFF
--- a/src/modules/plugins/__.js
+++ b/src/modules/plugins/__.js
@@ -20,7 +20,7 @@ export default (key, params = null) => {
     }
 
     return !!params && typeof params === 'object'
-        ? translation.replace(/:(\w*)/g, (e, key) => {
+        ? translation.replace(/:(\w+)/g, (e, key) => {
             if (typeof params[key.toLowerCase()] === 'undefined') {
                 return key;
             }


### PR DESCRIPTION
Require at least 1 character behind the : to trigger replace (allowing for `:` on it's own to appear)