### PR TITLE
fix arabic language

### DIFF
--- a/src/bulma/pages/calendar/components/EnsoCalendar.vue
+++ b/src/bulma/pages/calendar/components/EnsoCalendar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="calendar-wrapper box is-paddingless raises-on-hover">
         <vue-cal :time-from="7 * 60"
-            :locale="lang"
+            :locale="lang == 'ar' ? 'en' : lang"
             :events="events"
             show-all-day-events
             :disable-views="['years']"

--- a/src/bulma/pages/calendar/components/EnsoCalendar.vue
+++ b/src/bulma/pages/calendar/components/EnsoCalendar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="calendar-wrapper box is-paddingless raises-on-hover">
         <vue-cal :time-from="7 * 60"
-            :locale="lang == 'ar' ? 'en' : lang"
+            :locale="lang === 'ar' ? 'en' : lang"
             :events="events"
             show-all-day-events
             :disable-views="['years']"


### PR DESCRIPTION
Because there is no Arabic lang for Vue-cal.
this change uses English for the Arabic language. [calendar issue1](https://github.com/laravel-enso/calendar/issues/1)