### PR TITLE
added check for having the route in the state obj

### DIFF
--- a/src/modules/store.js
+++ b/src/modules/store.js
@@ -92,7 +92,7 @@ const actions = {
 
             const loginRoutes = ['login', 'password.email', 'password.reset'];
 
-            if (!loginRoutes.includes(state.route.name)) {
+            if (! state.route || !loginRoutes.includes(state.route.name)) {
                 router.push({ name: 'login' });
             }
         });


### PR DESCRIPTION
we sometimes encounter this error 
```
Cannot read properties of undefined (reading 'name')
```
when a user clears his browser's cache (and probably in other, harder to reproduce, scenarios as well) and then tries to navigate within the app.

![image](https://user-images.githubusercontent.com/14071925/164448162-dc172891-5940-4f79-be12-d050bbc38285.png)

Added a simple check to make sure we have the route object in state.

Did not use `?.` since this is more explicit as well as didn't want to add the file to the list of explicitly transpiled files.